### PR TITLE
Mitigate reversions on merkle deposits from decimal discrepancies

### DIFF
--- a/src/core/DepositLocker.sol
+++ b/src/core/DepositLocker.sol
@@ -738,7 +738,9 @@ contract DepositLocker is Ownable2Step, ReentrancyGuardTransient {
         // IMPORTANT: Dust amount is locked in the Deposit Locker forever.
         // Dust does not scale with the number of deposits bridged.
         uint256 decimalConversionRate = 10 ** (marketInputToken.decimals() - tokenToLzV2OFT[marketInputToken].sharedDecimals());
-        totalAmountDeposited = (totalAmountDeposited / decimalConversionRate) * decimalConversionRate;
+        if (decimalConversionRate != 1) {
+            totalAmountDeposited = (totalAmountDeposited / decimalConversionRate) * decimalConversionRate;
+        }
 
         // Ensure that at least one depositor was included in the bridge payload
         require(totalAmountDeposited > 0, MustBridgeAtLeastOneDepositor());


### PR DESCRIPTION
Move decimal normalization to the single token merkle bridge function instead of merkle deposit. Will mitigate unnecessary reversions on merkle deposit.